### PR TITLE
Fix TypeORM Migration Script Paths in package.json

### DIFF
--- a/apps/backend/backend-main/package.json
+++ b/apps/backend/backend-main/package.json
@@ -23,8 +23,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "migration-generate": "rm -rf out && npm run build && ./node_modules/.bin/typeorm migration:generate --dataSource './out/ormconfig.js' --pretty true",
     "migration-create": "npm run build && ./node_modules/.bin/typeorm migration:create",
-    "migration-run": "npm run build && node ./out/node_modules/typeorm/cli.js migration:run --dataSource ./out/ormconfig.js",
-    "migration-revert": "npm run build && node ./out/node_modules/typeorm/cli.js migration:revert --dataSource ./out/ormconfig.js",
+    "migration-run": "npm run build && node ./node_modules/typeorm/cli.js migration:run --dataSource ./out/ormconfig.js",
+    "migration-revert": "npm run build && node ./node_modules/typeorm/cli.js migration:revert --dataSource ./out/ormconfig.js",
     "commit": "git-cz"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

This PR updates the `migration-run` and `migration-revert` scripts in the `package.json` file to correct the path to the TypeORM CLI. The path has been changed from `./out/node_modules/typeorm/cli.js` to `./node_modules/typeorm/cli.js` to ensure proper execution of migration commands.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Ran the updated `migration-run` script to verify migrations execute successfully.  
- Ran the updated `migration-revert` script to confirm migrations can be reverted properly.  
- Confirmed no errors occur related to incorrect paths.

## Checklist:

- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  

## Screenshots (if appropriate):

N/A

## Additional context

This change resolves issues caused by incorrect file paths when running TypeORM migration scripts, ensuring smoother development workflows.
