### PR TITLE
feat: Saved Address Module

### DIFF
--- a/apps/backend/backend-main/src/entity/SavedAddress.ts
+++ b/apps/backend/backend-main/src/entity/SavedAddress.ts
@@ -1,0 +1,29 @@
+import { Entity, Column, ManyToOne, JoinColumn, Index } from "typeorm";
+import { BaseEntity } from "./BaseEntity";
+import { User } from "./User";
+
+@Index("IDX_saved_address_userId", ["userId"], { where: '"deletedAt" IS NULL' })
+@Entity()
+export class SavedAddress extends BaseEntity {
+  @ManyToOne(() => User, { deferrable: "INITIALLY IMMEDIATE", onDelete: "CASCADE" })
+  @JoinColumn({ name: "userId" })
+  user: User;
+
+  @Column({ type: "varchar", length: 255, nullable: false })
+  title: string; // e.g., "Home", "Work", etc.
+
+  @Column({ type: "varchar", length: 255, nullable: false })
+  addressLine1: string;
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  addressLine2: string;
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  landmark: string;
+
+  @Column({ type: "float", nullable: false })
+  latitude: number;
+
+  @Column({ type: "float", nullable: false })
+  longitude: number;
+}

--- a/apps/backend/backend-main/src/modules/user/user.controller.ts
+++ b/apps/backend/backend-main/src/modules/user/user.controller.ts
@@ -33,7 +33,8 @@ import { OnboardingGuard } from "../../shared/guards/onboarding.guard";
 import { RoleGuard } from "../../shared/guards/roles.guard";
 import { IApiResponse, ICustomRequest } from "../../shared/interface";
 import { UserService } from "./user.service";
-import { TCreateUser, TGetUserProfile, TUpdateUser } from "./user.types";
+import { TCreateSavedAddress, TCreateUser, TGetUserProfile, TUpdateSavedAddress, TUpdateUser } from "./user.types";
+import { SavedAddress } from "../../entity/SavedAddress";
 
 @ApiTags("User")
 @Controller("user")
@@ -284,4 +285,53 @@ export class UserController {
       };
     }
   }
+
+  @Post("address")
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRoleEnum.CUSTOMER)
+  async createAddress(
+    @Body() createAddressDto: TCreateSavedAddress,
+    @Req() request: ICustomRequest,
+  ): Promise<IApiResponse<SavedAddress>> {
+    const userId = request.user.id;
+    const address = await this.userService.createSavedAddress(userId, createAddressDto);
+    return { success: true, message: "Address created successfully.", data: address };
+  }
+
+  @Patch("address/:id")
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRoleEnum.CUSTOMER)
+  async updateAddress(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() updateAddressDto: TUpdateSavedAddress,
+    @Req() request: ICustomRequest,
+  ): Promise<IApiResponse<UpdateResult>> {
+    const userId = request.user.id;
+    const result = await this.userService.updateSavedAddress(userId, id, updateAddressDto);
+    return { success: true, message: "Address updated successfully.", data: result };
+  }
+
+  @Delete("address/:id")
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRoleEnum.CUSTOMER)
+  async deleteAddress(
+    @Param("id", ParseIntPipe) id: number,
+    @Req() request: ICustomRequest,
+  ): Promise<IApiResponse<DeleteResult>> {
+    const userId = request.user.id;
+    const result = await this.userService.deleteSavedAddress(userId, id);
+    return { success: true, message: "Address deleted successfully.", data: result };
+  }
+
+  @Get("address")
+  @UseGuards(AuthGuard, RoleGuard)
+  @Roles(UserRoleEnum.CUSTOMER)
+  async getAddresses(
+    @Req() request: ICustomRequest,
+  ): Promise<IApiResponse<SavedAddress[]>> {
+    const userId = request.user.id;
+    const addresses = await this.userService.getSavedAddresses(userId);
+    return { success: true, message: "Addresses retrieved successfully.", data: addresses };
+  }
+
 }

--- a/apps/backend/backend-main/src/modules/user/user.types.ts
+++ b/apps/backend/backend-main/src/modules/user/user.types.ts
@@ -30,6 +30,18 @@ export type TUpdateUser = {
   postalCode?: number;
 };
 
+export type TCreateSavedAddress = {
+  title: string;
+  addressLine1: string;
+  addressLine2?: string;
+  landmark?: string;
+  latitude: number;
+  longitude: number;
+};
+
+export type TUpdateSavedAddress = Partial<TCreateSavedAddress>;
+
+
 /**
  * Data Transfer Object for retrieving user profile based on specific criteria.
  */


### PR DESCRIPTION
### **Key Changes:**
1. **Created `SavedAddress` Entity:**
   - Stores user addresses with fields such as `title`, `addressLine1`, `latitude`, `longitude`, and optional fields like `addressLine2` and `landmark`.
   - Establishes a `ManyToOne` relationship with `User`, ensuring each address belongs to a specific user.

2. **Updated `UserController`:**
   - Added CRUD endpoints:
     - `POST /user/address` – Save a new address.
     - `PATCH /user/address/:id` – Update an existing address.
     - `DELETE /user/address/:id` – Remove a saved address.
     - `GET /user/address` – Retrieve all saved addresses for a user.
   - Restricted these endpoints to **authenticated users** with the `CUSTOMER` role.

3. **Updated `UserService`:**
   - Added methods to handle **creating, updating, deleting, and fetching saved addresses**.
   - Prevents duplicate address titles for the same user.
   - Ensures only the **owner of an address** can modify or delete it.

4. **Updated `User Types`:**
   - Introduced `TCreateSavedAddress` and `TUpdateSavedAddress` DTOs for request validation.

5. **Enhanced API Response Handling:**
   - Returns **structured error messages** if a user attempts to save an address with an existing title.
   - Ensures the response format is consistent across endpoints.
